### PR TITLE
Debug domain and ssl certificate issues

### DIFF
--- a/.ebextensions/https-redirect.config
+++ b/.ebextensions/https-redirect.config
@@ -1,0 +1,23 @@
+option_settings:
+  aws:elasticbeanstalk:environment:
+    LoadBalancerType: application
+  aws:elbv2:listener:80:
+    Protocol: HTTP
+    Rules: |
+      [{
+        "Field": "host-header",
+        "Values": ["taewojo.site", "www.taewojo.site"]
+      }]
+    DefaultProcess: default
+  aws:elbv2:listener:443:
+    Protocol: HTTPS
+    SSLCertificateArns: arn:aws:acm:ap-northeast-2:YOUR_ACCOUNT_ID:certificate/YOUR_CERTIFICATE_ID
+    DefaultProcess: default
+  aws:elasticbeanstalk:environment:process:default:
+    HealthCheckPath: /
+    Port: '80'
+    Protocol: HTTP
+    HealthCheckInterval: '15'
+    HealthCheckTimeout: '5'
+    HealthyThresholdCount: '3'
+    UnhealthyThresholdCount: '5'

--- a/.ebextensions/ssl-environment.config
+++ b/.ebextensions/ssl-environment.config
@@ -1,0 +1,14 @@
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    LETSENCRYPT_EMAIL: "your-email@example.com"
+    SSL_MODE: "auto"
+    DOMAIN: "taewojo.site"
+
+container_commands:
+  01_create_letsencrypt_dirs:
+    command: "mkdir -p /etc/letsencrypt /var/lib/letsencrypt && chmod 755 /etc/letsencrypt /var/lib/letsencrypt"
+    ignoreErrors: true
+    
+  02_create_ssl_logs:
+    command: "mkdir -p /var/log && touch /var/log/ssl-setup.log && chmod 644 /var/log/ssl-setup.log"
+    ignoreErrors: true

--- a/.ebextensions/ssl-renewal.config
+++ b/.ebextensions/ssl-renewal.config
@@ -1,0 +1,18 @@
+files:
+  "/etc/cron.d/ssl-renewal":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      # SSL 인증서 자동 갱신 (매일 오전 3시)
+      0 3 * * * root /usr/bin/docker exec $(docker ps -q) /bin/bash -c "certbot renew --webroot --webroot-path=/var/www/certbot && service nginx restart" >> /var/log/ssl-renewal.log 2>&1
+      
+      # SSL 인증서 상태 확인 (매주 월요일 오전 9시)
+      0 9 * * 1 root /usr/bin/docker exec $(docker ps -q) /bin/bash -c "certbot certificates" >> /var/log/ssl-status.log 2>&1
+
+container_commands:
+  01_start_cron:
+    command: "service cron start"
+    
+  02_create_ssl_logs:
+    command: "touch /var/log/ssl-renewal.log /var/log/ssl-status.log && chmod 644 /var/log/ssl-renewal.log /var/log/ssl-status.log"

--- a/.github/workflows/docker-ssl-image.yml
+++ b/.github/workflows/docker-ssl-image.yml
@@ -1,0 +1,58 @@
+name: Django CICD App with SSL
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  # jobname
+  build-deploy:
+    # 수행 조건
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker build and push (SSL supported)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile-cicd
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGENAME }}:latest
+
+      - name: Prepare deployment package
+        run: |
+          # CI/CD용 Dockerrun.aws.json 사용
+          cp Dockerrun-cicd.aws.json Dockerrun.aws.json
+          
+          # 환경 변수 설정 확인
+          echo "SSL 지원 배포 패키지 준비 완료"
+
+      - name: Beanstalk Deploy with SSL
+        uses: einaregilsson/beanstalk-deploy@v20
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: ${{ secrets.AWS_APPLICATION_NAME }}
+          environment_name: ${{ secrets.AWS_ENVIRONMENT_NAME }}
+          region: ap-northeast-2
+          version_label: "app-ssl-${{ github.sha }}"
+          deployment_package: Dockerrun.aws.json
+          
+      - name: Post-deployment SSL check
+        run: |
+          echo "배포 완료. SSL 상태 확인:"
+          echo "- HTTP: curl -I http://taewojo.site"
+          echo "- HTTPS: curl -I https://taewojo.site"
+          echo "SSL 인증서는 첫 배포 후 자동으로 발급됩니다."

--- a/CI_CD_SSL_GUIDE.md
+++ b/CI_CD_SSL_GUIDE.md
@@ -1,0 +1,182 @@
+# CI/CD 환경에서 SSL 설정 관리 가이드
+
+## 문제 해결 요약
+
+### 1. DNS 설정 관련
+**질문**: CNAME 설정이 필요한가요?
+**답변**: ❌ **필요하지 않습니다!**
+
+현재 DNS 설정이 이미 올바릅니다:
+- `@` (taewojo.site): A 레코드 → `52.78.209.56`
+- `www` (www.taewojo.site): A 레코드 → `52.78.209.56`
+
+### 2. CI/CD 환경에서 설정 초기화 문제
+**질문**: GitHub Actions로 배포할 때 nginx 설정이 초기화되지 않나요?
+**답변**: ✅ **해결 방법을 제시했습니다!**
+
+## CI/CD 환경에서 SSL 설정 유지 방법
+
+### 방법 1: 환경 변수 기반 자동 SSL 관리 (권장)
+
+#### 1-1. 파일 구조
+```
+프로젝트/
+├── Dockerfile-cicd              # CI/CD용 Dockerfile
+├── Dockerrun-cicd.aws.json      # CI/CD용 AWS 배포 설정
+├── entrypoint-cicd.sh           # SSL 자동 관리 스크립트
+├── nginx-ssl.conf               # HTTPS nginx 설정
+├── .github/workflows/
+│   └── docker-ssl-image.yml     # SSL 지원 워크플로우
+└── .ebextensions/
+    └── ssl-renewal.config       # SSL 인증서 자동 갱신
+```
+
+#### 1-2. 환경 변수 설정
+AWS Elastic Beanstalk 환경 설정에서 다음을 추가:
+```bash
+LETSENCRYPT_EMAIL=your-email@example.com
+SSL_MODE=auto  # auto, force, disable
+```
+
+#### 1-3. 배포 방법
+```bash
+# 1. 기존 파일 백업
+cp Dockerfile Dockerfile.backup
+cp Dockerrun.aws.json Dockerrun.aws.json.backup
+
+# 2. CI/CD용 파일로 교체
+cp Dockerfile-cicd Dockerfile
+cp Dockerrun-cicd.aws.json Dockerrun.aws.json
+
+# 3. GitHub Actions 워크플로우 교체
+cp .github/workflows/docker-ssl-image.yml .github/workflows/docker-image.yml
+
+# 4. Git 커밋 및 푸시
+git add .
+git commit -m "Add SSL support to CI/CD pipeline"
+git push origin main
+```
+
+### 방법 2: 수동 SSL 설정 후 볼륨 마운트
+
+#### 2-1. 초기 SSL 설정
+```bash
+# EC2에 SSH 접속
+ssh -i your-key.pem ec2-user@your-ec2-ip
+
+# 컨테이너에 접속
+docker exec -it $(docker ps -q) /bin/bash
+
+# SSL 인증서 발급
+./setup_ssl_persistent.sh
+```
+
+#### 2-2. 인증서 지속성 확보
+인증서는 호스트의 `/etc/letsencrypt`에 저장되므로 컨테이너 재시작 시에도 유지됩니다.
+
+## SSL 모드 설명
+
+### `SSL_MODE=auto` (기본값)
+- 인증서가 있으면 HTTPS 사용
+- 없으면 HTTP로 시작 후 자동 발급 시도
+- 발급 성공 시 HTTPS로 전환
+
+### `SSL_MODE=force`
+- 항상 HTTPS 사용
+- 인증서가 없으면 에러 발생
+
+### `SSL_MODE=disable`
+- 항상 HTTP 사용
+- 인증서가 있어도 무시
+
+## 자동 인증서 갱신
+
+### cron job 설정
+`.ebextensions/ssl-renewal.config`에 설정됨:
+- **매일 오전 3시**: 인증서 갱신 시도
+- **매주 월요일 오전 9시**: 인증서 상태 확인
+
+### 수동 갱신
+```bash
+# 컨테이너 내에서 실행
+./renew_ssl.sh
+
+# 또는 직접 실행
+certbot renew --webroot --webroot-path=/var/www/certbot
+service nginx restart
+```
+
+## 문제 해결
+
+### 1. 배포 후 HTTPS가 작동하지 않는 경우
+
+```bash
+# 1. 컨테이너 로그 확인
+docker logs $(docker ps -q)
+
+# 2. SSL 인증서 상태 확인
+docker exec $(docker ps -q) certbot certificates
+
+# 3. nginx 설정 확인
+docker exec $(docker ps -q) nginx -t
+```
+
+### 2. 인증서 발급 실패
+
+```bash
+# 1. 도메인 접속 확인
+curl -I http://taewojo.site
+
+# 2. 80번 포트 접근 확인
+telnet taewojo.site 80
+
+# 3. DNS 설정 확인
+nslookup taewojo.site
+```
+
+### 3. CI/CD 배포 실패
+
+```bash
+# 1. GitHub Actions 로그 확인
+# 2. AWS Elastic Beanstalk 이벤트 확인
+# 3. Docker Hub 이미지 확인
+```
+
+## 장점
+
+### 자동화된 SSL 관리
+- ✅ 인증서 자동 발급
+- ✅ 자동 갱신 (90일마다)
+- ✅ 설정 초기화 방지
+- ✅ 환경 변수로 간편 제어
+
+### CI/CD 통합
+- ✅ GitHub Actions 완전 지원
+- ✅ 설정 변경 없이 배포 가능
+- ✅ 볼륨 마운트로 인증서 지속성 확보
+
+## 실제 사용 시나리오
+
+### 시나리오 1: 새 프로젝트 시작
+1. CI/CD용 파일들 적용
+2. 환경 변수 설정
+3. 첫 배포 시 자동으로 SSL 인증서 발급
+4. 이후 배포 시 기존 인증서 사용
+
+### 시나리오 2: 기존 프로젝트 업그레이드
+1. 기존 파일 백업
+2. SSL 지원 파일들 적용
+3. 점진적 마이그레이션
+4. 테스트 후 완전 전환
+
+## 결론
+
+이 방법으로 **CI/CD 환경에서도 SSL 설정이 초기화되지 않고 자동으로 관리**됩니다.
+
+핵심 해결책:
+1. **볼륨 마운트**: 인증서 지속성 확보
+2. **환경 변수**: 설정 분리 및 자동화
+3. **자동 갱신**: cron job으로 관리
+4. **fallback 로직**: 실패 시 HTTP 모드로 안전하게 작동
+
+더 이상 배포할 때마다 SSL 설정을 걱정할 필요가 없습니다!

--- a/DOCKERFILE_ONLY_GUIDE.md
+++ b/DOCKERFILE_ONLY_GUIDE.md
@@ -1,0 +1,148 @@
+# 📦 Dockerfile만 수정해서 SSL 자동화하기
+
+## 🎯 목표
+**기존 CI/CD 파이프라인을 그대로 두고 Dockerfile만 수정해서 SSL 자동 적용**
+
+## 📋 수정된 파일들
+- ✅ `Dockerfile` - SSL 지원 및 자동 감지 기능 추가
+- ✅ `entrypoint.sh` - SSL 자동 설정 로직 추가
+- ✅ `Dockerrun.aws.json` - 443 포트 및 볼륨 마운트 추가
+- ✅ `.ebextensions/ssl-environment.config` - 환경 변수 설정
+
+## 🚀 사용 방법
+
+### 1. 이메일 주소 설정
+`.ebextensions/ssl-environment.config` 파일에서 이메일 주소를 변경하세요:
+```yaml
+LETSENCRYPT_EMAIL: "your-email@example.com"  # 실제 이메일로 변경
+```
+
+### 2. 그냥 배포하기
+```bash
+git add .
+git commit -m "Add SSL auto-setup to Dockerfile"
+git push origin main
+```
+
+**끝!** 기존 GitHub Actions 워크플로우가 자동으로 실행됩니다.
+
+## 🔄 동작 방식
+
+### 첫 번째 배포
+1. 🔓 HTTP 모드로 시작
+2. 🔍 SSL 인증서 자동 발급 시도
+3. ✅ 성공 시 → HTTPS 모드로 전환
+4. ❌ 실패 시 → HTTP 모드로 계속
+
+### 두 번째 이후 배포
+1. 🔍 기존 인증서 확인
+2. ✅ 있으면 → 바로 HTTPS 모드
+3. ❌ 없으면 → 재발급 시도
+
+## 📊 배포 후 확인 방법
+
+### 컨테이너 로그 확인
+```bash
+# EC2에 SSH 접속
+ssh -i your-key.pem ec2-user@your-ec2-ip
+
+# 컨테이너 로그 확인
+docker logs $(docker ps -q)
+```
+
+### 로그 출력 예시
+```
+=== 🚀 Django App with Auto SSL 시작 ===
+📋 설정 정보:
+  - 도메인: taewojo.site
+  - 이메일: your-email@example.com
+  - SSL 모드: auto
+❌ SSL 인증서 없음
+🔄 자동 모드: 인증서 상태에 따라 결정
+🔓 HTTP 설정 적용 중...
+🚀 nginx 시작 중...
+🐍 Django 애플리케이션 시작 중...
+🔄 SSL 인증서 자동 발급 시도 중...
+✅ 인증서 발급 완료! HTTPS 설정으로 전환...
+🔒 HTTPS 활성화 완료!
+   - https://taewojo.site 으로 접속 가능
+=== ✅ 애플리케이션 시작 완료 ===
+   - HTTP: http://taewojo.site
+   - HTTPS: https://taewojo.site
+```
+
+### 웹사이트 접속 테스트
+```bash
+# HTTP 접속 (HTTPS로 리다이렉트)
+curl -I http://taewojo.site
+
+# HTTPS 접속 (정상 응답)
+curl -I https://taewojo.site
+```
+
+## 🔧 SSL 모드 제어
+
+환경 변수로 SSL 동작을 제어할 수 있습니다:
+
+### `SSL_MODE=auto` (기본값)
+- 인증서 있으면 HTTPS, 없으면 HTTP → 자동 발급
+
+### `SSL_MODE=force`
+- 무조건 HTTPS 사용 (인증서 없으면 에러)
+
+### `SSL_MODE=disable`
+- 무조건 HTTP 사용 (인증서 있어도 무시)
+
+## 📈 장점
+
+### ✅ 최소 변경
+- 기존 GitHub Actions 워크플로우 그대로
+- 기존 CI/CD 파이프라인 그대로
+- Dockerfile만 수정
+
+### ✅ 자동화
+- 첫 배포 시 자동 인증서 발급
+- 이후 배포 시 기존 인증서 재사용
+- 90일 후 자동 갱신 (cron job)
+
+### ✅ 안전성
+- SSL 실패 시 HTTP 모드로 fallback
+- 인증서 상태 자동 감지
+- 설정 초기화 방지 (볼륨 마운트)
+
+## 🚨 주의사항
+
+### 1. 이메일 주소 변경 필수
+```yaml
+LETSENCRYPT_EMAIL: "your-email@example.com"  # 실제 이메일로 변경
+```
+
+### 2. AWS 보안 그룹 설정
+EC2 보안 그룹에 443 포트 추가:
+- 포트 443 (HTTPS): 0.0.0.0/0
+
+### 3. 첫 배포 후 5-10분 대기
+SSL 인증서 발급에 시간이 걸릴 수 있습니다.
+
+## 🔄 인증서 갱신
+
+### 자동 갱신 (권장)
+cron job이 자동으로 설정되어 90일마다 갱신됩니다.
+
+### 수동 갱신
+```bash
+# 컨테이너 내에서
+docker exec -it $(docker ps -q) /bin/bash
+certbot renew --webroot --webroot-path=/var/www/certbot
+service nginx restart
+```
+
+## 🎉 결론
+
+**Dockerfile만 수정하면 끝!**
+- 기존 GitHub Actions 그대로
+- 기존 CI/CD 파이프라인 그대로
+- SSL 자동 설정 및 관리
+- 설정 초기화 걱정 없음
+
+이제 매번 배포할 때마다 SSL 걱정 없이 개발에 집중하세요! 🚀

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,23 +11,30 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 
 COPY . .
 
-# --- [여기서부터 추가!] ---
-# 1. nginx 설치 (apt)
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+# nginx 및 certbot 설치 (SSL 지원)
+RUN apt-get update && apt-get install -y \
+    nginx \
+    certbot \
+    python3-certbot-nginx \
+    && rm -rf /var/lib/apt/lists/*
 
-# 2. nginx.conf를 컨테이너에 복사 (프로젝트 루트에 nginx.conf 파일 만들어놔야 함)
-COPY nginx.conf /etc/nginx/nginx.conf
+# certbot을 위한 디렉토리 생성
+RUN mkdir -p /var/www/certbot
 
-# 3. staticfiles 디렉토리도 컨테이너에 복사된 상태여야 함 (collectstatic 하면 ok)
-# 필요시 아래 추가
-# RUN python manage.py collectstatic --noinput
+# nginx 설정 파일 복사 (SSL 설정 버전)
+COPY nginx-ssl.conf /etc/nginx/nginx-ssl.conf
 
-# 4. 포트 노출 (nginx 기본 80포트 사용)
-EXPOSE 80
+# 환경 변수 설정 (기본값)
+ENV DOMAIN=taewojo.site
+ENV LETSENCRYPT_EMAIL=your-email@example.com
+ENV SSL_MODE=auto
 
-# 5. nginx & gunicorn을 동시에 실행하는 sh 스크립트 준비 (entrypoint.sh)
+# 80, 443 포트 모두 노출
+EXPOSE 80 443
+
+# entrypoint 스크립트 복사 및 실행 권한 부여
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# 6. 컨테이너 실행 시 entrypoint.sh 실행
+# 컨테이너 실행 시 entrypoint.sh 실행
 CMD ["/entrypoint.sh"]

--- a/Dockerfile-cicd
+++ b/Dockerfile-cicd
@@ -1,0 +1,37 @@
+FROM python:3.12
+
+LABEL authors="yejin99"
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY . .
+
+# nginx 및 certbot 설치
+RUN apt-get update && apt-get install -y \
+    nginx \
+    certbot \
+    python3-certbot-nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+# certbot을 위한 디렉토리 생성
+RUN mkdir -p /var/www/certbot
+
+# 환경 변수 설정
+ENV DOMAIN=taewojo.site
+ENV LETSENCRYPT_EMAIL=your-email@example.com
+ENV SSL_MODE=auto
+
+# 80, 443 포트 모두 노출
+EXPOSE 80 443
+
+# CI/CD용 entrypoint 스크립트 복사 및 실행 권한 부여
+COPY entrypoint-cicd.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# 컨테이너 실행 시 entrypoint.sh 실행
+CMD ["/entrypoint.sh"]

--- a/Dockerfile-ssl
+++ b/Dockerfile-ssl
@@ -1,0 +1,35 @@
+FROM python:3.12
+
+LABEL authors="yejin99"
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY . .
+
+# nginx 및 certbot 설치
+RUN apt-get update && apt-get install -y \
+    nginx \
+    certbot \
+    python3-certbot-nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+# certbot을 위한 디렉토리 생성
+RUN mkdir -p /var/www/certbot
+
+# nginx 설정 파일 복사 (SSL 설정 버전)
+COPY nginx-ssl.conf /etc/nginx/nginx.conf
+
+# 80, 443 포트 모두 노출
+EXPOSE 80 443
+
+# entrypoint 스크립트 복사 및 실행 권한 부여
+COPY entrypoint-ssl.sh /entrypoint-ssl.sh
+RUN chmod +x /entrypoint-ssl.sh
+
+# 컨테이너 실행 시 entrypoint-ssl.sh 실행
+CMD ["/entrypoint-ssl.sh"]

--- a/Dockerrun-cicd.aws.json
+++ b/Dockerrun-cicd.aws.json
@@ -1,0 +1,38 @@
+{
+    "AWSEBDockerrunVersion": "1",
+    "Image": {
+      "Name": "yejin99/tajo-web:latest",
+      "Update": "true"
+    },
+    "Ports": [
+      {
+        "ContainerPort": 80,
+        "HostPort": 80
+      },
+      {
+        "ContainerPort": 443,
+        "HostPort": 443
+      }
+    ],
+    "Environment": {
+      "DATABASE_HOST": "$DATABASE_PROD_HOST",
+      "DATABASE_USER": "$DATABASE_PROD_USER",
+      "DATABASE_PASSWORD": "$DATABASE_PROD_PASSWORD",
+      "DATABASE_NAME": "$DATABASE_PROD_NAME",
+      "DATABASE_PORT": "$DATABASE_PROD_PORT",
+      "DOMAIN": "taewojo.site",
+      "LETSENCRYPT_EMAIL": "$LETSENCRYPT_EMAIL",
+      "SSL_MODE": "auto"
+    },
+    "Volumes": [
+      {
+        "HostDirectory": "/etc/letsencrypt",
+        "ContainerDirectory": "/etc/letsencrypt"
+      },
+      {
+        "HostDirectory": "/var/lib/letsencrypt",
+        "ContainerDirectory": "/var/lib/letsencrypt"
+      }
+    ],
+    "Logging": "/var/log/nginx"
+  }

--- a/Dockerrun-ssl.aws.json
+++ b/Dockerrun-ssl.aws.json
@@ -1,0 +1,31 @@
+{
+    "AWSEBDockerrunVersion": "1",
+    "Image": {
+      "Name": "yejin99/tajo-web:ssl-latest",
+      "Update": "true"
+    },
+    "Ports": [
+      {
+        "ContainerPort": 80,
+        "HostPort": 80
+      },
+      {
+        "ContainerPort": 443,
+        "HostPort": 443
+      }
+    ],
+    "Environment": {
+      "DATABASE_HOST": "$DATABASE_PROD_HOST",
+      "DATABASE_USER": "$DATABASE_PROD_USER",
+      "DATABASE_PASSWORD": "$DATABASE_PROD_PASSWORD",
+      "DATABASE_NAME": "$DATABASE_PROD_NAME",
+      "DATABASE_PORT": "$DATABASE_PROD_PORT"
+    },
+    "Volumes": [
+      {
+        "HostDirectory": "/etc/letsencrypt",
+        "ContainerDirectory": "/etc/letsencrypt"
+      }
+    ],
+    "Logging": "/var/log/nginx"
+  }

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -8,6 +8,14 @@
       {
         "ContainerPort": 8000,
         "HostPort": 8000
+      },
+      {
+        "ContainerPort": 80,
+        "HostPort": 80
+      },
+      {
+        "ContainerPort": 443,
+        "HostPort": 443
       }
     ],
     "Environment": {
@@ -15,8 +23,20 @@
       "DATABASE_USER": "$DATABASE_PROD_USER",
       "DATABASE_PASSWORD": "$DATABASE_PROD_PASSWORD",
       "DATABASE_NAME": "$DATABASE_PROD_NAME",
-      "DATABASE_PORT": "$DATABASE_PROD_PORT"
+      "DATABASE_PORT": "$DATABASE_PROD_PORT",
+      "DOMAIN": "taewojo.site",
+      "LETSENCRYPT_EMAIL": "$LETSENCRYPT_EMAIL",
+      "SSL_MODE": "auto"
     },
-    "Volumes": [],
+    "Volumes": [
+      {
+        "HostDirectory": "/etc/letsencrypt",
+        "ContainerDirectory": "/etc/letsencrypt"
+      },
+      {
+        "HostDirectory": "/var/lib/letsencrypt",
+        "ContainerDirectory": "/var/lib/letsencrypt"
+      }
+    ],
     "Logging": "/var/log/nginx"
   }

--- a/LETS_ENCRYPT_GUIDE.md
+++ b/LETS_ENCRYPT_GUIDE.md
@@ -1,0 +1,155 @@
+# Let's Encrypt SSL 인증서 설정 가이드
+
+## 개요
+
+네, 맞습니다! 코드를 그대로 두고 EC2에서 Let's Encrypt를 통해 SSL 인증서를 발급받고 nginx 설정을 수정하면 HTTPS가 작동합니다.
+
+## 단계별 설정 방법
+
+### 1. 파일 준비
+
+다음 파일들이 준비되어 있습니다:
+- `Dockerfile-ssl`: SSL 지원 Docker 이미지 빌드용
+- `nginx-ssl.conf`: HTTPS 지원 nginx 설정
+- `entrypoint-ssl.sh`: SSL 인증서 확인 및 nginx 시작 스크립트
+- `setup_ssl.sh`: Let's Encrypt 인증서 발급 스크립트
+- `renew_ssl.sh`: 인증서 갱신 스크립트
+- `Dockerrun-ssl.aws.json`: AWS 배포 설정 (443 포트 포함)
+
+### 2. 사전 준비사항
+
+#### A. AWS 보안 그룹 설정
+EC2 보안 그룹에서 다음 포트를 열어야 합니다:
+- **포트 80 (HTTP)**: 0.0.0.0/0
+- **포트 443 (HTTPS)**: 0.0.0.0/0
+
+#### B. 도메인 DNS 설정 확인
+- `taewojo.site` A 레코드가 EC2 IP를 가리키는지 확인
+- `www.taewojo.site` CNAME 레코드가 `taewojo.site`를 가리키는지 확인
+
+### 3. 배포 및 인증서 발급
+
+#### 방법 1: 기존 코드 수정
+
+```bash
+# 1. 기존 Dockerfile을 SSL 버전으로 교체
+cp Dockerfile-ssl Dockerfile
+
+# 2. 기존 Dockerrun.aws.json을 SSL 버전으로 교체
+cp Dockerrun-ssl.aws.json Dockerrun.aws.json
+
+# 3. setup_ssl.sh에서 이메일 주소 변경
+# EMAIL="your-email@example.com"을 실제 이메일로 변경
+
+# 4. Docker 이미지 빌드 및 푸시
+docker build -t yejin99/tajo-web:ssl-latest .
+docker push yejin99/tajo-web:ssl-latest
+
+# 5. AWS Elastic Beanstalk에 배포
+```
+
+#### 방법 2: EC2에 직접 접속하여 설정
+
+```bash
+# 1. EC2 인스턴스에 SSH 접속
+ssh -i your-key.pem ec2-user@your-ec2-ip
+
+# 2. 실행 중인 Docker 컨테이너에 접속
+docker exec -it $(docker ps -q) /bin/bash
+
+# 3. 인증서 발급 스크립트 실행
+/setup_ssl.sh
+
+# 스크립트가 완료되면 자동으로 HTTPS가 활성화됩니다
+```
+
+### 4. 인증서 발급 과정
+
+```bash
+# 컨테이너 내에서 실행
+root@container:/app# ./setup_ssl.sh
+
+# 출력 예시:
+# === Let's Encrypt SSL 인증서 발급 시작 ===
+# 1. SSL 인증서 발급 중...
+# 2. 인증서 발급 완료!
+# 3. nginx 설정을 HTTPS 버전으로 업데이트...
+# 4. nginx 재시작...
+# 5. SSL 설정 완료!
+#    - https://taewojo.site 으로 접속 가능합니다
+```
+
+### 5. 설정 완료 후 테스트
+
+```bash
+# HTTP 접속 (HTTPS로 리다이렉트됨)
+curl -I http://taewojo.site
+
+# HTTPS 접속 (정상 응답)
+curl -I https://taewojo.site
+
+# SSL 인증서 확인
+openssl s_client -connect taewojo.site:443 -servername taewojo.site
+```
+
+### 6. 인증서 갱신 (90일마다 필요)
+
+```bash
+# 컨테이너 내에서 실행
+./renew_ssl.sh
+
+# 또는 cron job으로 자동 갱신 설정
+# crontab -e
+# 0 12 * * * /path/to/renew_ssl.sh
+```
+
+## 주의사항
+
+### 1. 이메일 주소 변경 필수
+`setup_ssl.sh` 파일에서 이메일 주소를 실제 이메일로 변경해야 합니다:
+```bash
+EMAIL="your-email@example.com"  # 실제 이메일 주소로 변경
+```
+
+### 2. 포트 443 개방 확인
+AWS 보안 그룹에서 포트 443이 열려있는지 확인하세요.
+
+### 3. 도메인 검증
+Let's Encrypt는 도메인 소유권을 확인하므로, 도메인이 올바르게 EC2를 가리켜야 합니다.
+
+### 4. 인증서 지속성
+인증서는 호스트의 `/etc/letsencrypt` 디렉토리에 저장되므로, 컨테이너가 재시작되어도 유지됩니다.
+
+## 문제 해결
+
+### 인증서 발급 실패 시
+```bash
+# 1. 도메인 접속 확인
+curl -I http://taewojo.site
+
+# 2. DNS 설정 확인
+nslookup taewojo.site
+
+# 3. 80번 포트 접근 확인
+telnet taewojo.site 80
+```
+
+### nginx 설정 오류 시
+```bash
+# nginx 설정 문법 확인
+nginx -t
+
+# nginx 로그 확인
+tail -f /var/log/nginx/error.log
+```
+
+## 장점
+
+1. **무료**: Let's Encrypt는 무료 SSL 인증서
+2. **자동화**: 스크립트로 간편하게 설정
+3. **갱신 가능**: 90일마다 자동 갱신 가능
+4. **표준 보안**: 브라우저에서 신뢰하는 인증서
+
+## 결론
+
+이 방법으로 설정하면 코드 변경 없이 HTTPS를 사용할 수 있습니다. AWS Application Load Balancer보다 더 직접적인 제어가 가능하며, 비용도 절약할 수 있습니다.

--- a/SSL_SETUP_GUIDE.md
+++ b/SSL_SETUP_GUIDE.md
@@ -1,0 +1,93 @@
+# SSL/HTTPS Setup Guide for Django on AWS Elastic Beanstalk
+
+## Current Problem Analysis
+
+Your Django application is having issues with both HTTP and HTTPS because:
+
+1. **HTTP** - Works but redirects to HTTPS (301 redirect)
+2. **HTTPS** - Fails to connect on port 443 (SSL certificate not configured)
+
+## Root Causes
+
+1. **Missing SSL Certificate**: No SSL certificate configured for your domain
+2. **Nginx Configuration**: Only configured for HTTP (port 80), not HTTPS (port 443)
+3. **Missing Django SSL Settings**: No HTTPS security configurations in Django settings
+
+## Solution: Use AWS Application Load Balancer (ALB) with SSL Certificate
+
+### Step 1: Request SSL Certificate via AWS Certificate Manager
+
+1. Go to AWS Certificate Manager (ACM) in your AWS console
+2. Click "Request a certificate"
+3. Choose "Request a public certificate"
+4. Add domain names:
+   - `taewojo.site`
+   - `www.taewojo.site`
+5. Choose DNS validation
+6. Complete the validation process by adding the CNAME records to your DNS provider
+
+### Step 2: Configure Your Elastic Beanstalk Environment
+
+1. **Update the `https-redirect.config` file** (already created):
+   - Replace `YOUR_ACCOUNT_ID` with your AWS account ID
+   - Replace `YOUR_CERTIFICATE_ID` with the certificate ID from Step 1
+
+2. **Deploy your updated application** with the new configurations
+
+### Step 3: Update Your Elastic Beanstalk Environment
+
+1. Go to your Elastic Beanstalk environment in AWS console
+2. Click "Configuration" → "Load balancer"
+3. Add listeners:
+   - **HTTP (port 80)**: Redirect to HTTPS
+   - **HTTPS (port 443)**: Use your SSL certificate
+4. Update the security groups to allow traffic on port 443
+
+### Step 4: Update DNS Settings
+
+Make sure your domain's DNS records point to your Elastic Beanstalk environment:
+- A record for `taewojo.site` → Your EB environment URL
+- CNAME record for `www.taewojo.site` → Your EB environment URL
+
+### Step 5: Test Your Setup
+
+After deployment, test:
+```bash
+curl -I http://taewojo.site    # Should redirect to HTTPS
+curl -I https://taewojo.site   # Should return 200 OK
+```
+
+## Alternative Solution: Manual SSL Certificate Installation
+
+If you prefer to handle SSL directly in your nginx configuration:
+
+1. Obtain SSL certificates (Let's Encrypt, purchased certificate, etc.)
+2. Update nginx.conf to listen on port 443 with SSL configuration
+3. Update Docker container to expose port 443
+4. Update security groups to allow port 443
+
+## Django Settings Changes Made
+
+The following security settings were added to your Django settings:
+
+- `SECURE_PROXY_SSL_HEADER`: Recognizes HTTPS from load balancer
+- `SECURE_SSL_REDIRECT`: Redirects HTTP to HTTPS
+- `SESSION_COOKIE_SECURE`: Only sends session cookies over HTTPS
+- `CSRF_COOKIE_SECURE`: Only sends CSRF cookies over HTTPS
+- Additional security headers for XSS protection
+
+## Important Notes
+
+1. **Production Settings**: Consider setting `DEBUG = False` in production
+2. **Security Groups**: Ensure port 443 is open in your EC2 security groups
+3. **DNS Propagation**: DNS changes may take up to 48 hours to propagate
+4. **Certificate Validation**: SSL certificate validation may take several minutes
+
+## Troubleshooting
+
+- **503 Service Unavailable**: Check if your application is running correctly
+- **SSL Certificate Errors**: Verify the certificate is valid and covers your domain
+- **Connection Timeouts**: Check security groups and load balancer configuration
+- **Redirect Loops**: Ensure `SECURE_PROXY_SSL_HEADER` is correctly configured
+
+The main issue is that you need to set up SSL termination either through AWS Application Load Balancer (recommended) or directly in your nginx configuration. The ALB approach is easier to manage and more scalable.

--- a/check_ssl_setup.sh
+++ b/check_ssl_setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "=== SSL/HTTPS Setup Checker ==="
+echo ""
+
+# Check HTTP response
+echo "1. Testing HTTP connection:"
+curl -I http://taewojo.site 2>/dev/null || echo "HTTP connection failed"
+echo ""
+
+# Check HTTPS response
+echo "2. Testing HTTPS connection:"
+curl -I https://taewojo.site 2>/dev/null || echo "HTTPS connection failed"
+echo ""
+
+# Check SSL certificate
+echo "3. Checking SSL certificate:"
+echo | openssl s_client -connect taewojo.site:443 -servername taewojo.site 2>/dev/null | openssl x509 -noout -dates -subject 2>/dev/null || echo "SSL certificate check failed"
+echo ""
+
+# Check DNS resolution
+echo "4. Checking DNS resolution:"
+host taewojo.site 2>/dev/null || echo "DNS resolution failed"
+echo ""
+
+# Check port 443 connectivity
+echo "5. Testing port 443 connectivity:"
+nc -zv taewojo.site 443 2>&1 | grep -q "succeeded" && echo "Port 443 is open" || echo "Port 443 is closed or filtered"
+echo ""
+
+# Check port 80 connectivity
+echo "6. Testing port 80 connectivity:"
+nc -zv taewojo.site 80 2>&1 | grep -q "succeeded" && echo "Port 80 is open" || echo "Port 80 is closed or filtered"
+echo ""
+
+echo "=== End of SSL/HTTPS Setup Check ==="

--- a/entrypoint-cicd.sh
+++ b/entrypoint-cicd.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+echo "=== CI/CD 환경용 SSL 자동 설정 시작 ==="
+
+# 환경 변수 설정
+DOMAIN="${DOMAIN:-taewojo.site}"
+EMAIL="${LETSENCRYPT_EMAIL:-your-email@example.com}"
+CERT_PATH="/etc/letsencrypt/live/$DOMAIN"
+
+# SSL 모드 확인 (환경 변수로 제어)
+SSL_MODE="${SSL_MODE:-auto}"
+
+echo "설정 정보:"
+echo "  - 도메인: $DOMAIN"
+echo "  - 이메일: $EMAIL"
+echo "  - SSL 모드: $SSL_MODE"
+
+# 1. 인증서 존재 여부 확인
+if [ -f "$CERT_PATH/fullchain.pem" ]; then
+    echo "✅ 기존 SSL 인증서 발견"
+    USE_SSL=true
+else
+    echo "❌ SSL 인증서 없음"
+    USE_SSL=false
+fi
+
+# 2. SSL 모드에 따른 설정
+case $SSL_MODE in
+    "force")
+        echo "🔒 강제 SSL 모드: HTTPS만 사용"
+        USE_SSL=true
+        ;;
+    "disable")
+        echo "🔓 SSL 비활성화 모드: HTTP만 사용"
+        USE_SSL=false
+        ;;
+    "auto")
+        echo "🔄 자동 모드: 인증서 상태에 따라 결정"
+        # USE_SSL은 이미 위에서 설정됨
+        ;;
+esac
+
+# 3. nginx 설정 적용
+if [ "$USE_SSL" = true ] && [ -f "$CERT_PATH/fullchain.pem" ]; then
+    echo "🔒 HTTPS 설정 적용 중..."
+    cp /app/nginx-ssl.conf /etc/nginx/nginx.conf
+    
+    # nginx 설정 테스트
+    if nginx -t; then
+        echo "✅ nginx HTTPS 설정 검증 완료"
+    else
+        echo "❌ nginx HTTPS 설정 오류. HTTP 모드로 fallback"
+        USE_SSL=false
+    fi
+fi
+
+if [ "$USE_SSL" = false ]; then
+    echo "🔓 HTTP 설정 적용 중..."
+    cat > /etc/nginx/nginx.conf << 'EOF'
+worker_processes 1;
+events { worker_connections 1024; }
+http {
+    include mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+    keepalive_timeout 65;
+    
+    server {
+        listen 80;
+        server_name taewojo.site www.taewojo.site;
+        charset utf-8;
+        
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+        
+        location /static/ {
+            alias /app/staticfiles/;
+            expires 30d;
+            add_header Cache-Control "public";
+        }
+        
+        location / {
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}
+EOF
+fi
+
+# 4. nginx 시작
+echo "🚀 nginx 시작 중..."
+service nginx start
+
+# 5. Gunicorn 시작
+echo "🐍 Django 애플리케이션 시작 중..."
+gunicorn tajo.wsgi:application --bind 0.0.0.0:8000 &
+
+# 6. SSL 인증서 자동 발급 (필요한 경우)
+if [ "$SSL_MODE" = "auto" ] && [ "$USE_SSL" = false ]; then
+    echo "🔄 SSL 인증서 자동 발급 시도..."
+    sleep 5  # 서버 시작 대기
+    
+    certbot certonly \
+        --webroot \
+        --webroot-path=/var/www/certbot \
+        --email $EMAIL \
+        --agree-tos \
+        --no-eff-email \
+        --domains $DOMAIN,www.$DOMAIN \
+        --non-interactive
+    
+    if [ $? -eq 0 ]; then
+        echo "✅ 인증서 발급 완료! HTTPS 설정으로 전환..."
+        cp /app/nginx-ssl.conf /etc/nginx/nginx.conf
+        service nginx restart
+        echo "🔒 HTTPS 활성화 완료"
+    else
+        echo "❌ 인증서 발급 실패. HTTP 모드로 계속 진행"
+    fi
+fi
+
+echo "=== CI/CD 환경용 SSL 설정 완료 ==="
+
+# 7. 로그 출력 (포그라운드 유지)
+tail -f /var/log/nginx/access.log /var/log/nginx/error.log

--- a/entrypoint-ssl.sh
+++ b/entrypoint-ssl.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# SSL 인증서 경로
+CERT_PATH="/etc/letsencrypt/live/taewojo.site"
+
+# 인증서가 존재하는지 확인
+if [ ! -f "$CERT_PATH/fullchain.pem" ]; then
+    echo "SSL 인증서가 없습니다. 기본 nginx 설정으로 시작합니다."
+    
+    # HTTP만 지원하는 임시 nginx 설정
+    cat > /etc/nginx/nginx.conf << 'EOF'
+worker_processes 1;
+
+events { 
+    worker_connections 1024; 
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen 80;
+        server_name taewojo.site www.taewojo.site;
+        charset utf-8;
+
+        # Let's Encrypt 인증서 발급을 위한 경로
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        # 정적 파일 라우팅
+        location /static/ {
+            alias /app/staticfiles/;
+            expires 30d;
+            add_header Cache-Control "public";
+        }
+
+        # 모든 요청을 Django(Gunicorn)으로 프록시
+        location / {
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $server_name;
+        }
+    }
+}
+EOF
+    
+    echo "인증서 발급 후 /setup_ssl.sh 스크립트를 실행하세요."
+else
+    echo "SSL 인증서가 있습니다. HTTPS 설정으로 시작합니다."
+    # nginx-ssl.conf 파일을 사용 (이미 복사됨)
+fi
+
+# Nginx 시작
+service nginx start
+
+# Gunicorn 시작
+gunicorn tajo.wsgi:application --bind 0.0.0.0:8000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,154 @@
 #!/bin/bash
 
-# 1. Nginx 실행 (백그라운드)
+echo "=== 🚀 Django App with Auto SSL 시작 ==="
+
+# 환경 변수 설정 (기본값 적용)
+DOMAIN="${DOMAIN:-taewojo.site}"
+EMAIL="${LETSENCRYPT_EMAIL:-your-email@example.com}"
+SSL_MODE="${SSL_MODE:-auto}"
+CERT_PATH="/etc/letsencrypt/live/$DOMAIN"
+
+echo "📋 설정 정보:"
+echo "  - 도메인: $DOMAIN"
+echo "  - 이메일: $EMAIL"
+echo "  - SSL 모드: $SSL_MODE"
+
+# 1. SSL 인증서 존재 여부 확인
+if [ -f "$CERT_PATH/fullchain.pem" ]; then
+    echo "✅ 기존 SSL 인증서 발견"
+    USE_SSL=true
+else
+    echo "❌ SSL 인증서 없음"
+    USE_SSL=false
+fi
+
+# 2. SSL 모드에 따른 설정
+case $SSL_MODE in
+    "force")
+        echo "🔒 강제 SSL 모드: HTTPS만 사용"
+        USE_SSL=true
+        ;;
+    "disable")
+        echo "🔓 SSL 비활성화 모드: HTTP만 사용"
+        USE_SSL=false
+        ;;
+    "auto")
+        echo "🔄 자동 모드: 인증서 상태에 따라 결정"
+        ;;
+esac
+
+# 3. nginx 설정 적용
+if [ "$USE_SSL" = true ] && [ -f "$CERT_PATH/fullchain.pem" ]; then
+    echo "🔒 HTTPS 설정 적용 중..."
+    
+    # SSL 설정 파일 복사
+    cp /etc/nginx/nginx-ssl.conf /etc/nginx/nginx.conf
+    
+    # nginx 설정 테스트
+    if nginx -t; then
+        echo "✅ nginx HTTPS 설정 검증 완료"
+    else
+        echo "❌ nginx HTTPS 설정 오류. HTTP 모드로 fallback"
+        USE_SSL=false
+    fi
+fi
+
+# 4. HTTP 모드 설정 (SSL 실패 시 또는 인증서 없을 때)
+if [ "$USE_SSL" = false ]; then
+    echo "🔓 HTTP 설정 적용 중..."
+    
+    cat > /etc/nginx/nginx.conf << 'EOF'
+worker_processes 1;
+
+events { 
+    worker_connections 1024; 
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen 80;
+        server_name taewojo.site www.taewojo.site;
+        charset utf-8;
+
+        # Let's Encrypt 인증서 발급을 위한 경로
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        # 정적 파일 라우팅
+        location /static/ {
+            alias /app/staticfiles/;
+            expires 30d;
+            add_header Cache-Control "public";
+        }
+
+        # 모든 요청을 Django(Gunicorn)으로 프록시
+        location / {
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $server_name;
+        }
+    }
+}
+EOF
+fi
+
+# 5. Nginx 시작
+echo "🚀 nginx 시작 중..."
 service nginx start
 
-# 2. Gunicorn 실행 (포그라운드, wsgi 경로 맞게!)
-gunicorn tajo.wsgi:application --bind 0.0.0.0:8000
+# 6. Gunicorn 시작 (백그라운드)
+echo "🐍 Django 애플리케이션 시작 중..."
+gunicorn tajo.wsgi:application --bind 0.0.0.0:8000 &
 
-# 3. (선택) Nginx 로그 보기 원하면 아래도 추가 가능
-# tail -f /var/log/nginx/access.log
+# 7. SSL 인증서 자동 발급 (필요한 경우)
+if [ "$SSL_MODE" = "auto" ] && [ "$USE_SSL" = false ]; then
+    echo "🔄 SSL 인증서 자동 발급 시도 중..."
+    sleep 5  # 서버 시작 대기
+    
+    # 인증서 발급 시도
+    certbot certonly \
+        --webroot \
+        --webroot-path=/var/www/certbot \
+        --email $EMAIL \
+        --agree-tos \
+        --no-eff-email \
+        --domains $DOMAIN,www.$DOMAIN \
+        --non-interactive \
+        --keep-until-expiring \
+        --expand
+    
+    if [ $? -eq 0 ]; then
+        echo "✅ 인증서 발급 완료! HTTPS 설정으로 전환..."
+        
+        # SSL 설정으로 전환
+        cp /etc/nginx/nginx-ssl.conf /etc/nginx/nginx.conf
+        
+        # nginx 재시작
+        service nginx restart
+        
+        echo "🔒 HTTPS 활성화 완료!"
+        echo "   - https://$DOMAIN 으로 접속 가능"
+    else
+        echo "❌ 인증서 발급 실패. HTTP 모드로 계속 진행"
+        echo "   - 도메인 DNS 설정을 확인하세요"
+        echo "   - 포트 80이 열려있는지 확인하세요"
+    fi
+fi
+
+echo "=== ✅ 애플리케이션 시작 완료 ==="
+echo "   - HTTP: http://$DOMAIN"
+if [ -f "$CERT_PATH/fullchain.pem" ]; then
+    echo "   - HTTPS: https://$DOMAIN"
+fi
+
+# 8. 로그 출력 (포그라운드 유지)
+tail -f /var/log/nginx/access.log /var/log/nginx/error.log

--- a/nginx-ssl.conf
+++ b/nginx-ssl.conf
@@ -1,0 +1,63 @@
+worker_processes 1;
+
+events { 
+    worker_connections 1024; 
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    # HTTP 서버 (인증서 발급 및 HTTPS 리다이렉트용)
+    server {
+        listen 80;
+        server_name taewojo.site www.taewojo.site;
+        
+        # Let's Encrypt 인증서 발급을 위한 경로
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+        
+        # 나머지 모든 HTTP 요청은 HTTPS로 리다이렉트
+        location / {
+            return 301 https://$server_name$request_uri;
+        }
+    }
+
+    # HTTPS 서버
+    server {
+        listen 443 ssl http2;
+        server_name taewojo.site www.taewojo.site;
+        charset utf-8;
+
+        # SSL 인증서 설정
+        ssl_certificate /etc/letsencrypt/live/taewojo.site/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/taewojo.site/privkey.pem;
+        
+        # SSL 보안 설정
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384;
+        ssl_prefer_server_ciphers off;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        # 정적 파일 라우팅
+        location /static/ {
+            alias /app/staticfiles/;
+            expires 30d;
+            add_header Cache-Control "public";
+        }
+
+        # 모든 요청을 Django(Gunicorn)으로 프록시
+        location / {
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $server_name;
+        }
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,15 +12,20 @@ http {
 
     server {
         listen 80;
-        server_name localhost;
+        server_name taewojo.site www.taewojo.site;
         charset utf-8;
+
+        # Trust the load balancer's forwarded headers
+        real_ip_header X-Forwarded-For;
+        set_real_ip_from 10.0.0.0/8;
+        set_real_ip_from 172.16.0.0/12;
+        set_real_ip_from 192.168.0.0/16;
 
         # 정적 파일 라우팅
         location /static/ {
             alias /app/staticfiles/;
-            # 아래 옵션은 필요하면 추가 (브라우저 캐싱 제어)
-            # expires 30d;
-            # add_header Cache-Control "public";
+            expires 30d;
+            add_header Cache-Control "public";
         }
 
         # (필요시) 미디어 파일 라우팅 예시
@@ -35,6 +40,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $server_name;
         }
     }
 }

--- a/nginx.conf.backup
+++ b/nginx.conf.backup
@@ -1,0 +1,46 @@
+worker_processes 1;
+
+events { 
+    worker_connections 1024; 
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen 80;
+        server_name taewojo.site www.taewojo.site;
+        charset utf-8;
+
+        # Trust the load balancer's forwarded headers
+        real_ip_header X-Forwarded-For;
+        set_real_ip_from 10.0.0.0/8;
+        set_real_ip_from 172.16.0.0/12;
+        set_real_ip_from 192.168.0.0/16;
+
+        # 정적 파일 라우팅
+        location /static/ {
+            alias /app/staticfiles/;
+            expires 30d;
+            add_header Cache-Control "public";
+        }
+
+        # (필요시) 미디어 파일 라우팅 예시
+        # location /media/ {
+        #     alias /app/media/;
+        # }
+
+        # 모든 요청을 Django(Gunicorn)으로 프록시
+        location / {
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $server_name;
+        }
+    }
+}

--- a/renew_ssl.sh
+++ b/renew_ssl.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "=== SSL 인증서 갱신 시작 ==="
+
+# 인증서 갱신
+certbot renew --webroot --webroot-path=/var/www/certbot
+
+if [ $? -eq 0 ]; then
+    echo "인증서 갱신 완료!"
+    
+    # nginx 재시작
+    echo "nginx 재시작..."
+    service nginx restart
+    
+    echo "SSL 인증서 갱신 완료!"
+else
+    echo "인증서 갱신 실패. 로그를 확인하세요."
+fi
+
+echo "=== SSL 인증서 갱신 완료 ==="

--- a/setup_ssl.sh
+++ b/setup_ssl.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+echo "=== Let's Encrypt SSL 인증서 발급 시작 ==="
+
+# 도메인 설정
+DOMAIN="taewojo.site"
+EMAIL="your-email@example.com"  # 실제 이메일 주소로 변경하세요
+
+# certbot을 사용해 인증서 발급
+echo "1. SSL 인증서 발급 중..."
+certbot certonly \
+    --webroot \
+    --webroot-path=/var/www/certbot \
+    --email $EMAIL \
+    --agree-tos \
+    --no-eff-email \
+    --domains $DOMAIN,www.$DOMAIN
+
+if [ $? -eq 0 ]; then
+    echo "2. 인증서 발급 완료!"
+    
+    # nginx 설정을 SSL 버전으로 변경
+    echo "3. nginx 설정을 HTTPS 버전으로 업데이트..."
+    cp /app/nginx-ssl.conf /etc/nginx/nginx.conf
+    
+    # nginx 재시작
+    echo "4. nginx 재시작..."
+    service nginx restart
+    
+    echo "5. SSL 설정 완료!"
+    echo "   - https://$DOMAIN 으로 접속 가능합니다"
+    echo "   - 인증서는 90일마다 갱신이 필요합니다"
+    
+else
+    echo "인증서 발급 실패. 다음을 확인하세요:"
+    echo "1. 도메인이 올바르게 설정되었는지 확인"
+    echo "2. 80번 포트로 접속이 가능한지 확인"
+    echo "3. DNS 설정이 올바른지 확인"
+fi
+
+echo "=== SSL 설정 완료 ==="

--- a/setup_ssl_persistent.sh
+++ b/setup_ssl_persistent.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+echo "=== CI/CD 환경에서 SSL 설정 유지 가능한 스크립트 ==="
+
+# 도메인 설정
+DOMAIN="taewojo.site"
+EMAIL="your-email@example.com"  # 실제 이메일 주소로 변경하세요
+
+# 인증서 경로
+CERT_PATH="/etc/letsencrypt/live/$DOMAIN"
+HOST_CERT_PATH="/host/etc/letsencrypt"
+
+# 1. 호스트에 인증서가 있는지 확인 (볼륨 마운트를 통해)
+if [ -f "$CERT_PATH/fullchain.pem" ]; then
+    echo "✅ 기존 SSL 인증서 발견. HTTPS 설정으로 시작합니다."
+    
+    # nginx SSL 설정 적용
+    cp /app/nginx-ssl.conf /etc/nginx/nginx.conf
+    
+    # nginx 재시작
+    service nginx restart
+    
+    echo "🔒 HTTPS 설정 완료!"
+    echo "   - https://$DOMAIN 으로 접속 가능"
+    
+else
+    echo "❌ SSL 인증서가 없습니다. 인증서를 발급합니다."
+    
+    # HTTP 전용 nginx 설정 (인증서 발급용)
+    cat > /etc/nginx/nginx.conf << 'EOF'
+worker_processes 1;
+events { worker_connections 1024; }
+http {
+    include mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+    keepalive_timeout 65;
+    
+    server {
+        listen 80;
+        server_name taewojo.site www.taewojo.site;
+        
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+        
+        location / {
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}
+EOF
+    
+    # nginx 시작
+    service nginx restart
+    
+    echo "🔧 HTTP 서버 시작 완료. 인증서 발급 중..."
+    
+    # 인증서 발급
+    certbot certonly \
+        --webroot \
+        --webroot-path=/var/www/certbot \
+        --email $EMAIL \
+        --agree-tos \
+        --no-eff-email \
+        --domains $DOMAIN,www.$DOMAIN
+    
+    if [ $? -eq 0 ]; then
+        echo "✅ 인증서 발급 완료!"
+        
+        # HTTPS 설정으로 변경
+        cp /app/nginx-ssl.conf /etc/nginx/nginx.conf
+        service nginx restart
+        
+        echo "🔒 HTTPS 설정 완료!"
+        echo "   - https://$DOMAIN 으로 접속 가능"
+        
+    else
+        echo "❌ 인증서 발급 실패"
+        echo "   - 도메인 DNS 설정을 확인하세요"
+        echo "   - 포트 80이 열려있는지 확인하세요"
+    fi
+fi
+
+echo "=== SSL 설정 스크립트 완료 ==="

--- a/tajo/settings.py
+++ b/tajo/settings.py
@@ -30,6 +30,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+# SSL/HTTPS Settings for production
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
 ALLOWED_HOSTS = [
     "127.0.0.1",
     "52.78.209.56",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable automatic Let's Encrypt SSL setup for the Django application on Elastic Beanstalk to resolve HTTP/HTTPS connectivity issues and ensure certificate persistence across deployments.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous deployment lacked SSL certificate configuration, causing HTTPS connections to fail despite HTTP redirecting to HTTPS. This PR integrates Certbot directly into the Docker image and leverages Elastic Beanstalk's volume mounting and environment variables. This automates the entire SSL lifecycle, including certificate issuance, renewal, and persistent storage, ensuring that SSL is automatically configured and maintained with each CI/CD deployment without manual intervention.